### PR TITLE
Refine XML docs

### DIFF
--- a/src/Cryptie.Common/Features/Account/Validators/UserDisplayNameRequestValidator.cs
+++ b/src/Cryptie.Common/Features/Account/Validators/UserDisplayNameRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.Account.Validators;
 
 public class UserDisplayNameRequestValidator : AbstractValidator<UserDisplayNameRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserDisplayNameRequestValidator"/> class
+    /// and defines validation rules for user display name changes.
+    /// </summary>
     public UserDisplayNameRequestValidator()
     {
         RuleFor(x => x.Name)

--- a/src/Cryptie.Common/Features/Authentication/Validators/LoginRequestValidator.cs
+++ b/src/Cryptie.Common/Features/Authentication/Validators/LoginRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.Authentication.Validators;
 
 public class LoginRequestValidator : AbstractValidator<LoginRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginRequestValidator"/> class
+    /// and defines validation rules for user login requests.
+    /// </summary>
     public LoginRequestValidator()
     {
         RuleFor(x => x.Login)

--- a/src/Cryptie.Common/Features/Authentication/Validators/LogoutRequestValidator.cs
+++ b/src/Cryptie.Common/Features/Authentication/Validators/LogoutRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.Authentication.Validators;
 
 public class LogoutRequestValidator : AbstractValidator<LogoutRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LogoutRequestValidator"/> class
+    /// and configures validation rules for user logout.
+    /// </summary>
     public LogoutRequestValidator()
     {
         RuleFor(x => x.Token)

--- a/src/Cryptie.Common/Features/Authentication/Validators/RegisterRequestValidator.cs
+++ b/src/Cryptie.Common/Features/Authentication/Validators/RegisterRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.Authentication.Validators;
 
 public class RegisterRequestValidator : AbstractValidator<RegisterRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegisterRequestValidator"/> class
+    /// and specifies validation rules for new account registration.
+    /// </summary>
     public RegisterRequestValidator()
     {
         RuleFor(x => x.Login)

--- a/src/Cryptie.Common/Features/Authentication/Validators/TotpRequestValidator.cs
+++ b/src/Cryptie.Common/Features/Authentication/Validators/TotpRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.Authentication.Validators;
 
 public class TotpRequestValidator : AbstractValidator<TotpRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TotpRequestValidator"/> class
+    /// and establishes validation rules for two-factor authentication requests.
+    /// </summary>
     public TotpRequestValidator()
     {
         RuleFor(x => x.TotpToken)

--- a/src/Cryptie.Common/Features/UserManagement/Validators/AddFriendRequestValidator.cs
+++ b/src/Cryptie.Common/Features/UserManagement/Validators/AddFriendRequestValidator.cs
@@ -5,6 +5,10 @@ namespace Cryptie.Common.Features.UserManagement.Validators;
 
 public class AddFriendRequestValidator : AbstractValidator<AddFriendRequestDto>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddFriendRequestValidator"/> class
+    /// and sets up validation rules for adding a friend.
+    /// </summary>
     public AddFriendRequestValidator()
     {
         RuleFor(x => x.Friend)


### PR DESCRIPTION
## Summary
- remove doc comments from entity constructors to keep entities undocumented
- keep validator constructor documentation to describe validation logic